### PR TITLE
Typescript Axios returned types and export paths fixed

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-axios/api.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/api.mustache
@@ -16,6 +16,6 @@ import { BASE_PATH, COLLECTION_FORMATS, RequestArgs, BaseAPI, RequiredError } fr
 {{>apiInner}}
 {{/apis}}{{/apiInfo}}
 {{/withSeparateModelsAndApi}}{{#withSeparateModelsAndApi}}
-{{#apiInfo}}{{#apis}}{{#operations}}export * from './{{apiPackage}}/{{classFilename}}';
+{{#apiInfo}}{{#apis}}{{#operations}}export * from './{{tsApiPackage}}/{{classFilename}}';
 {{/operations}}{{/apis}}{{/apiInfo}}
 {{/withSeparateModelsAndApi}}

--- a/modules/openapi-generator/src/main/resources/typescript-axios/apiInner.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/apiInner.mustache
@@ -78,7 +78,7 @@ export const {{classname}}AxiosParamCreator = function (configuration?: Configur
             {{#isBasicBasic}}
             // http basic authentication required
             if (configuration && (configuration.username || configuration.password)) {
-                localVarRequestOptions["auth"] = { username: configuration.username, password: configuration.password }; 
+                localVarRequestOptions["auth"] = { username: configuration.username, password: configuration.password };
             }
             {{/isBasicBasic}}
             {{#isBasicBearer}}
@@ -256,7 +256,7 @@ export const {{classname}}Factory = function (configuration?: Configuration, bas
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}options?: any) {
+        {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}options?: any) : AxiosPromise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}> {
             return {{classname}}Fp(configuration).{{nickname}}({{#allParams}}{{paramName}}, {{/allParams}}options)(axios, basePath);
         },
     {{/operation}}
@@ -284,7 +284,7 @@ export interface {{classname}}Interface {
      * @throws {RequiredError}
      * @memberof {{classname}}Interface
      */
-    {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}options?: any): AxiosPromise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}{}{{/returnType}}>;
+    {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}options?: any): AxiosPromise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}>;
 
 {{/operation}}
 }

--- a/samples/client/petstore/typescript-axios/builds/default/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/default/api.ts
@@ -790,7 +790,7 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        addPet(body: Pet, options?: any) {
+        addPet(body: Pet, options?: any) : AxiosPromise<void> {
             return PetApiFp(configuration).addPet(body, options)(axios, basePath);
         },
         /**
@@ -801,7 +801,7 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        deletePet(petId: number, apiKey?: string, options?: any) {
+        deletePet(petId: number, apiKey?: string, options?: any) : AxiosPromise<void> {
             return PetApiFp(configuration).deletePet(petId, apiKey, options)(axios, basePath);
         },
         /**
@@ -811,7 +811,7 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: any) {
+        findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: any) : AxiosPromise<Array<Pet>> {
             return PetApiFp(configuration).findPetsByStatus(status, options)(axios, basePath);
         },
         /**
@@ -821,7 +821,7 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        findPetsByTags(tags: Array<string>, options?: any) {
+        findPetsByTags(tags: Array<string>, options?: any) : AxiosPromise<Array<Pet>> {
             return PetApiFp(configuration).findPetsByTags(tags, options)(axios, basePath);
         },
         /**
@@ -831,7 +831,7 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getPetById(petId: number, options?: any) {
+        getPetById(petId: number, options?: any) : AxiosPromise<Pet> {
             return PetApiFp(configuration).getPetById(petId, options)(axios, basePath);
         },
         /**
@@ -841,7 +841,7 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updatePet(body: Pet, options?: any) {
+        updatePet(body: Pet, options?: any) : AxiosPromise<void> {
             return PetApiFp(configuration).updatePet(body, options)(axios, basePath);
         },
         /**
@@ -853,7 +853,7 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updatePetWithForm(petId: number, name?: string, status?: string, options?: any) {
+        updatePetWithForm(petId: number, name?: string, status?: string, options?: any) : AxiosPromise<void> {
             return PetApiFp(configuration).updatePetWithForm(petId, name, status, options)(axios, basePath);
         },
         /**
@@ -865,7 +865,7 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        uploadFile(petId: number, additionalMetadata?: string, file?: any, options?: any) {
+        uploadFile(petId: number, additionalMetadata?: string, file?: any, options?: any) : AxiosPromise<ApiResponse> {
             return PetApiFp(configuration).uploadFile(petId, additionalMetadata, file, options)(axios, basePath);
         },
     };
@@ -1213,7 +1213,7 @@ export const StoreApiFactory = function (configuration?: Configuration, basePath
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        deleteOrder(orderId: string, options?: any) {
+        deleteOrder(orderId: string, options?: any) : AxiosPromise<void> {
             return StoreApiFp(configuration).deleteOrder(orderId, options)(axios, basePath);
         },
         /**
@@ -1222,7 +1222,7 @@ export const StoreApiFactory = function (configuration?: Configuration, basePath
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getInventory(options?: any) {
+        getInventory(options?: any) : AxiosPromise<{ [key: string]: number; }> {
             return StoreApiFp(configuration).getInventory(options)(axios, basePath);
         },
         /**
@@ -1232,7 +1232,7 @@ export const StoreApiFactory = function (configuration?: Configuration, basePath
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getOrderById(orderId: number, options?: any) {
+        getOrderById(orderId: number, options?: any) : AxiosPromise<Order> {
             return StoreApiFp(configuration).getOrderById(orderId, options)(axios, basePath);
         },
         /**
@@ -1242,7 +1242,7 @@ export const StoreApiFactory = function (configuration?: Configuration, basePath
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        placeOrder(body: Order, options?: any) {
+        placeOrder(body: Order, options?: any) : AxiosPromise<Order> {
             return StoreApiFp(configuration).placeOrder(body, options)(axios, basePath);
         },
     };
@@ -1753,7 +1753,7 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        createUser(body: User, options?: any) {
+        createUser(body: User, options?: any) : AxiosPromise<void> {
             return UserApiFp(configuration).createUser(body, options)(axios, basePath);
         },
         /**
@@ -1763,7 +1763,7 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithArrayInput(body: Array<User>, options?: any) {
+        createUsersWithArrayInput(body: Array<User>, options?: any) : AxiosPromise<void> {
             return UserApiFp(configuration).createUsersWithArrayInput(body, options)(axios, basePath);
         },
         /**
@@ -1773,7 +1773,7 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithListInput(body: Array<User>, options?: any) {
+        createUsersWithListInput(body: Array<User>, options?: any) : AxiosPromise<void> {
             return UserApiFp(configuration).createUsersWithListInput(body, options)(axios, basePath);
         },
         /**
@@ -1783,7 +1783,7 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        deleteUser(username: string, options?: any) {
+        deleteUser(username: string, options?: any) : AxiosPromise<void> {
             return UserApiFp(configuration).deleteUser(username, options)(axios, basePath);
         },
         /**
@@ -1793,7 +1793,7 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getUserByName(username: string, options?: any) {
+        getUserByName(username: string, options?: any) : AxiosPromise<User> {
             return UserApiFp(configuration).getUserByName(username, options)(axios, basePath);
         },
         /**
@@ -1804,7 +1804,7 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        loginUser(username: string, password: string, options?: any) {
+        loginUser(username: string, password: string, options?: any) : AxiosPromise<string> {
             return UserApiFp(configuration).loginUser(username, password, options)(axios, basePath);
         },
         /**
@@ -1813,7 +1813,7 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        logoutUser(options?: any) {
+        logoutUser(options?: any) : AxiosPromise<void> {
             return UserApiFp(configuration).logoutUser(options)(axios, basePath);
         },
         /**
@@ -1824,7 +1824,7 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateUser(username: string, body: User, options?: any) {
+        updateUser(username: string, body: User, options?: any) : AxiosPromise<void> {
             return UserApiFp(configuration).updateUser(username, body, options)(axios, basePath);
         },
     };

--- a/samples/client/petstore/typescript-axios/builds/es6-target/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/es6-target/api.ts
@@ -790,7 +790,7 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        addPet(body: Pet, options?: any) {
+        addPet(body: Pet, options?: any) : AxiosPromise<void> {
             return PetApiFp(configuration).addPet(body, options)(axios, basePath);
         },
         /**
@@ -801,7 +801,7 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        deletePet(petId: number, apiKey?: string, options?: any) {
+        deletePet(petId: number, apiKey?: string, options?: any) : AxiosPromise<void> {
             return PetApiFp(configuration).deletePet(petId, apiKey, options)(axios, basePath);
         },
         /**
@@ -811,7 +811,7 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: any) {
+        findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: any) : AxiosPromise<Array<Pet>> {
             return PetApiFp(configuration).findPetsByStatus(status, options)(axios, basePath);
         },
         /**
@@ -821,7 +821,7 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        findPetsByTags(tags: Array<string>, options?: any) {
+        findPetsByTags(tags: Array<string>, options?: any) : AxiosPromise<Array<Pet>> {
             return PetApiFp(configuration).findPetsByTags(tags, options)(axios, basePath);
         },
         /**
@@ -831,7 +831,7 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getPetById(petId: number, options?: any) {
+        getPetById(petId: number, options?: any) : AxiosPromise<Pet> {
             return PetApiFp(configuration).getPetById(petId, options)(axios, basePath);
         },
         /**
@@ -841,7 +841,7 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updatePet(body: Pet, options?: any) {
+        updatePet(body: Pet, options?: any) : AxiosPromise<void> {
             return PetApiFp(configuration).updatePet(body, options)(axios, basePath);
         },
         /**
@@ -853,7 +853,7 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updatePetWithForm(petId: number, name?: string, status?: string, options?: any) {
+        updatePetWithForm(petId: number, name?: string, status?: string, options?: any) : AxiosPromise<void> {
             return PetApiFp(configuration).updatePetWithForm(petId, name, status, options)(axios, basePath);
         },
         /**
@@ -865,7 +865,7 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        uploadFile(petId: number, additionalMetadata?: string, file?: any, options?: any) {
+        uploadFile(petId: number, additionalMetadata?: string, file?: any, options?: any) : AxiosPromise<ApiResponse> {
             return PetApiFp(configuration).uploadFile(petId, additionalMetadata, file, options)(axios, basePath);
         },
     };
@@ -1213,7 +1213,7 @@ export const StoreApiFactory = function (configuration?: Configuration, basePath
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        deleteOrder(orderId: string, options?: any) {
+        deleteOrder(orderId: string, options?: any) : AxiosPromise<void> {
             return StoreApiFp(configuration).deleteOrder(orderId, options)(axios, basePath);
         },
         /**
@@ -1222,7 +1222,7 @@ export const StoreApiFactory = function (configuration?: Configuration, basePath
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getInventory(options?: any) {
+        getInventory(options?: any) : AxiosPromise<{ [key: string]: number; }> {
             return StoreApiFp(configuration).getInventory(options)(axios, basePath);
         },
         /**
@@ -1232,7 +1232,7 @@ export const StoreApiFactory = function (configuration?: Configuration, basePath
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getOrderById(orderId: number, options?: any) {
+        getOrderById(orderId: number, options?: any) : AxiosPromise<Order> {
             return StoreApiFp(configuration).getOrderById(orderId, options)(axios, basePath);
         },
         /**
@@ -1242,7 +1242,7 @@ export const StoreApiFactory = function (configuration?: Configuration, basePath
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        placeOrder(body: Order, options?: any) {
+        placeOrder(body: Order, options?: any) : AxiosPromise<Order> {
             return StoreApiFp(configuration).placeOrder(body, options)(axios, basePath);
         },
     };
@@ -1753,7 +1753,7 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        createUser(body: User, options?: any) {
+        createUser(body: User, options?: any) : AxiosPromise<void> {
             return UserApiFp(configuration).createUser(body, options)(axios, basePath);
         },
         /**
@@ -1763,7 +1763,7 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithArrayInput(body: Array<User>, options?: any) {
+        createUsersWithArrayInput(body: Array<User>, options?: any) : AxiosPromise<void> {
             return UserApiFp(configuration).createUsersWithArrayInput(body, options)(axios, basePath);
         },
         /**
@@ -1773,7 +1773,7 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithListInput(body: Array<User>, options?: any) {
+        createUsersWithListInput(body: Array<User>, options?: any) : AxiosPromise<void> {
             return UserApiFp(configuration).createUsersWithListInput(body, options)(axios, basePath);
         },
         /**
@@ -1783,7 +1783,7 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        deleteUser(username: string, options?: any) {
+        deleteUser(username: string, options?: any) : AxiosPromise<void> {
             return UserApiFp(configuration).deleteUser(username, options)(axios, basePath);
         },
         /**
@@ -1793,7 +1793,7 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getUserByName(username: string, options?: any) {
+        getUserByName(username: string, options?: any) : AxiosPromise<User> {
             return UserApiFp(configuration).getUserByName(username, options)(axios, basePath);
         },
         /**
@@ -1804,7 +1804,7 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        loginUser(username: string, password: string, options?: any) {
+        loginUser(username: string, password: string, options?: any) : AxiosPromise<string> {
             return UserApiFp(configuration).loginUser(username, password, options)(axios, basePath);
         },
         /**
@@ -1813,7 +1813,7 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        logoutUser(options?: any) {
+        logoutUser(options?: any) : AxiosPromise<void> {
             return UserApiFp(configuration).logoutUser(options)(axios, basePath);
         },
         /**
@@ -1824,7 +1824,7 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateUser(username: string, body: User, options?: any) {
+        updateUser(username: string, body: User, options?: any) : AxiosPromise<void> {
             return UserApiFp(configuration).updateUser(username, body, options)(axios, basePath);
         },
     };

--- a/samples/client/petstore/typescript-axios/builds/with-complex-headers/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-complex-headers/api.ts
@@ -843,7 +843,7 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        addPet(pet: Pet, header1?: Pet, header2?: Array<Pet>, options?: any) {
+        addPet(pet: Pet, header1?: Pet, header2?: Array<Pet>, options?: any) : AxiosPromise<void> {
             return PetApiFp(configuration).addPet(pet, header1, header2, options)(axios, basePath);
         },
         /**
@@ -854,7 +854,7 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        deletePet(petId: number, apiKey?: string, options?: any) {
+        deletePet(petId: number, apiKey?: string, options?: any) : AxiosPromise<void> {
             return PetApiFp(configuration).deletePet(petId, apiKey, options)(axios, basePath);
         },
         /**
@@ -864,7 +864,7 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: any) {
+        findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: any) : AxiosPromise<Array<Pet>> {
             return PetApiFp(configuration).findPetsByStatus(status, options)(axios, basePath);
         },
         /**
@@ -874,7 +874,7 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        findPetsByTags(tags: Array<string>, options?: any) {
+        findPetsByTags(tags: Array<string>, options?: any) : AxiosPromise<Array<Pet>> {
             return PetApiFp(configuration).findPetsByTags(tags, options)(axios, basePath);
         },
         /**
@@ -884,7 +884,7 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getPetById(petId: number, options?: any) {
+        getPetById(petId: number, options?: any) : AxiosPromise<Pet> {
             return PetApiFp(configuration).getPetById(petId, options)(axios, basePath);
         },
         /**
@@ -894,7 +894,7 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updatePet(pet: Pet, options?: any) {
+        updatePet(pet: Pet, options?: any) : AxiosPromise<void> {
             return PetApiFp(configuration).updatePet(pet, options)(axios, basePath);
         },
         /**
@@ -906,7 +906,7 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updatePetWithForm(petId: number, name?: string, status?: string, options?: any) {
+        updatePetWithForm(petId: number, name?: string, status?: string, options?: any) : AxiosPromise<void> {
             return PetApiFp(configuration).updatePetWithForm(petId, name, status, options)(axios, basePath);
         },
         /**
@@ -918,7 +918,7 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        uploadFile(petId: number, additionalMetadata?: string, file?: any, options?: any) {
+        uploadFile(petId: number, additionalMetadata?: string, file?: any, options?: any) : AxiosPromise<ApiResponse> {
             return PetApiFp(configuration).uploadFile(petId, additionalMetadata, file, options)(axios, basePath);
         },
     };
@@ -1268,7 +1268,7 @@ export const StoreApiFactory = function (configuration?: Configuration, basePath
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        deleteOrder(orderId: string, options?: any) {
+        deleteOrder(orderId: string, options?: any) : AxiosPromise<void> {
             return StoreApiFp(configuration).deleteOrder(orderId, options)(axios, basePath);
         },
         /**
@@ -1277,7 +1277,7 @@ export const StoreApiFactory = function (configuration?: Configuration, basePath
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getInventory(options?: any) {
+        getInventory(options?: any) : AxiosPromise<{ [key: string]: number; }> {
             return StoreApiFp(configuration).getInventory(options)(axios, basePath);
         },
         /**
@@ -1287,7 +1287,7 @@ export const StoreApiFactory = function (configuration?: Configuration, basePath
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getOrderById(orderId: number, options?: any) {
+        getOrderById(orderId: number, options?: any) : AxiosPromise<Order> {
             return StoreApiFp(configuration).getOrderById(orderId, options)(axios, basePath);
         },
         /**
@@ -1297,7 +1297,7 @@ export const StoreApiFactory = function (configuration?: Configuration, basePath
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        placeOrder(order: Order, options?: any) {
+        placeOrder(order: Order, options?: any) : AxiosPromise<Order> {
             return StoreApiFp(configuration).placeOrder(order, options)(axios, basePath);
         },
     };
@@ -1808,7 +1808,7 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        createUser(user: User, options?: any) {
+        createUser(user: User, options?: any) : AxiosPromise<void> {
             return UserApiFp(configuration).createUser(user, options)(axios, basePath);
         },
         /**
@@ -1818,7 +1818,7 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithArrayInput(user: Array<User>, options?: any) {
+        createUsersWithArrayInput(user: Array<User>, options?: any) : AxiosPromise<void> {
             return UserApiFp(configuration).createUsersWithArrayInput(user, options)(axios, basePath);
         },
         /**
@@ -1828,7 +1828,7 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithListInput(user: Array<User>, options?: any) {
+        createUsersWithListInput(user: Array<User>, options?: any) : AxiosPromise<void> {
             return UserApiFp(configuration).createUsersWithListInput(user, options)(axios, basePath);
         },
         /**
@@ -1838,7 +1838,7 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        deleteUser(username: string, options?: any) {
+        deleteUser(username: string, options?: any) : AxiosPromise<void> {
             return UserApiFp(configuration).deleteUser(username, options)(axios, basePath);
         },
         /**
@@ -1848,7 +1848,7 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getUserByName(username: string, options?: any) {
+        getUserByName(username: string, options?: any) : AxiosPromise<User> {
             return UserApiFp(configuration).getUserByName(username, options)(axios, basePath);
         },
         /**
@@ -1859,7 +1859,7 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        loginUser(username: string, password: string, options?: any) {
+        loginUser(username: string, password: string, options?: any) : AxiosPromise<string> {
             return UserApiFp(configuration).loginUser(username, password, options)(axios, basePath);
         },
         /**
@@ -1868,7 +1868,7 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        logoutUser(options?: any) {
+        logoutUser(options?: any) : AxiosPromise<void> {
             return UserApiFp(configuration).logoutUser(options)(axios, basePath);
         },
         /**
@@ -1879,7 +1879,7 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateUser(username: string, user: User, options?: any) {
+        updateUser(username: string, user: User, options?: any) : AxiosPromise<void> {
             return UserApiFp(configuration).updateUser(username, user, options)(axios, basePath);
         },
     };

--- a/samples/client/petstore/typescript-axios/builds/with-interfaces/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-interfaces/api.ts
@@ -790,7 +790,7 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        addPet(body: Pet, options?: any) {
+        addPet(body: Pet, options?: any) : AxiosPromise<void> {
             return PetApiFp(configuration).addPet(body, options)(axios, basePath);
         },
         /**
@@ -801,7 +801,7 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        deletePet(petId: number, apiKey?: string, options?: any) {
+        deletePet(petId: number, apiKey?: string, options?: any) : AxiosPromise<void> {
             return PetApiFp(configuration).deletePet(petId, apiKey, options)(axios, basePath);
         },
         /**
@@ -811,7 +811,7 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: any) {
+        findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: any) : AxiosPromise<Array<Pet>> {
             return PetApiFp(configuration).findPetsByStatus(status, options)(axios, basePath);
         },
         /**
@@ -821,7 +821,7 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        findPetsByTags(tags: Array<string>, options?: any) {
+        findPetsByTags(tags: Array<string>, options?: any) : AxiosPromise<Array<Pet>> {
             return PetApiFp(configuration).findPetsByTags(tags, options)(axios, basePath);
         },
         /**
@@ -831,7 +831,7 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getPetById(petId: number, options?: any) {
+        getPetById(petId: number, options?: any) : AxiosPromise<Pet> {
             return PetApiFp(configuration).getPetById(petId, options)(axios, basePath);
         },
         /**
@@ -841,7 +841,7 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updatePet(body: Pet, options?: any) {
+        updatePet(body: Pet, options?: any) : AxiosPromise<void> {
             return PetApiFp(configuration).updatePet(body, options)(axios, basePath);
         },
         /**
@@ -853,7 +853,7 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updatePetWithForm(petId: number, name?: string, status?: string, options?: any) {
+        updatePetWithForm(petId: number, name?: string, status?: string, options?: any) : AxiosPromise<void> {
             return PetApiFp(configuration).updatePetWithForm(petId, name, status, options)(axios, basePath);
         },
         /**
@@ -865,7 +865,7 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        uploadFile(petId: number, additionalMetadata?: string, file?: any, options?: any) {
+        uploadFile(petId: number, additionalMetadata?: string, file?: any, options?: any) : AxiosPromise<ApiResponse> {
             return PetApiFp(configuration).uploadFile(petId, additionalMetadata, file, options)(axios, basePath);
         },
     };
@@ -885,7 +885,7 @@ export interface PetApiInterface {
      * @throws {RequiredError}
      * @memberof PetApiInterface
      */
-    addPet(body: Pet, options?: any): AxiosPromise<{}>;
+    addPet(body: Pet, options?: any): AxiosPromise<void>;
 
     /**
      * 
@@ -896,7 +896,7 @@ export interface PetApiInterface {
      * @throws {RequiredError}
      * @memberof PetApiInterface
      */
-    deletePet(petId: number, apiKey?: string, options?: any): AxiosPromise<{}>;
+    deletePet(petId: number, apiKey?: string, options?: any): AxiosPromise<void>;
 
     /**
      * Multiple status values can be provided with comma separated strings
@@ -936,7 +936,7 @@ export interface PetApiInterface {
      * @throws {RequiredError}
      * @memberof PetApiInterface
      */
-    updatePet(body: Pet, options?: any): AxiosPromise<{}>;
+    updatePet(body: Pet, options?: any): AxiosPromise<void>;
 
     /**
      * 
@@ -948,7 +948,7 @@ export interface PetApiInterface {
      * @throws {RequiredError}
      * @memberof PetApiInterface
      */
-    updatePetWithForm(petId: number, name?: string, status?: string, options?: any): AxiosPromise<{}>;
+    updatePetWithForm(petId: number, name?: string, status?: string, options?: any): AxiosPromise<void>;
 
     /**
      * 
@@ -1306,7 +1306,7 @@ export const StoreApiFactory = function (configuration?: Configuration, basePath
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        deleteOrder(orderId: string, options?: any) {
+        deleteOrder(orderId: string, options?: any) : AxiosPromise<void> {
             return StoreApiFp(configuration).deleteOrder(orderId, options)(axios, basePath);
         },
         /**
@@ -1315,7 +1315,7 @@ export const StoreApiFactory = function (configuration?: Configuration, basePath
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getInventory(options?: any) {
+        getInventory(options?: any) : AxiosPromise<{ [key: string]: number; }> {
             return StoreApiFp(configuration).getInventory(options)(axios, basePath);
         },
         /**
@@ -1325,7 +1325,7 @@ export const StoreApiFactory = function (configuration?: Configuration, basePath
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getOrderById(orderId: number, options?: any) {
+        getOrderById(orderId: number, options?: any) : AxiosPromise<Order> {
             return StoreApiFp(configuration).getOrderById(orderId, options)(axios, basePath);
         },
         /**
@@ -1335,7 +1335,7 @@ export const StoreApiFactory = function (configuration?: Configuration, basePath
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        placeOrder(body: Order, options?: any) {
+        placeOrder(body: Order, options?: any) : AxiosPromise<Order> {
             return StoreApiFp(configuration).placeOrder(body, options)(axios, basePath);
         },
     };
@@ -1355,7 +1355,7 @@ export interface StoreApiInterface {
      * @throws {RequiredError}
      * @memberof StoreApiInterface
      */
-    deleteOrder(orderId: string, options?: any): AxiosPromise<{}>;
+    deleteOrder(orderId: string, options?: any): AxiosPromise<void>;
 
     /**
      * Returns a map of status codes to quantities
@@ -1893,7 +1893,7 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        createUser(body: User, options?: any) {
+        createUser(body: User, options?: any) : AxiosPromise<void> {
             return UserApiFp(configuration).createUser(body, options)(axios, basePath);
         },
         /**
@@ -1903,7 +1903,7 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithArrayInput(body: Array<User>, options?: any) {
+        createUsersWithArrayInput(body: Array<User>, options?: any) : AxiosPromise<void> {
             return UserApiFp(configuration).createUsersWithArrayInput(body, options)(axios, basePath);
         },
         /**
@@ -1913,7 +1913,7 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithListInput(body: Array<User>, options?: any) {
+        createUsersWithListInput(body: Array<User>, options?: any) : AxiosPromise<void> {
             return UserApiFp(configuration).createUsersWithListInput(body, options)(axios, basePath);
         },
         /**
@@ -1923,7 +1923,7 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        deleteUser(username: string, options?: any) {
+        deleteUser(username: string, options?: any) : AxiosPromise<void> {
             return UserApiFp(configuration).deleteUser(username, options)(axios, basePath);
         },
         /**
@@ -1933,7 +1933,7 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getUserByName(username: string, options?: any) {
+        getUserByName(username: string, options?: any) : AxiosPromise<User> {
             return UserApiFp(configuration).getUserByName(username, options)(axios, basePath);
         },
         /**
@@ -1944,7 +1944,7 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        loginUser(username: string, password: string, options?: any) {
+        loginUser(username: string, password: string, options?: any) : AxiosPromise<string> {
             return UserApiFp(configuration).loginUser(username, password, options)(axios, basePath);
         },
         /**
@@ -1953,7 +1953,7 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        logoutUser(options?: any) {
+        logoutUser(options?: any) : AxiosPromise<void> {
             return UserApiFp(configuration).logoutUser(options)(axios, basePath);
         },
         /**
@@ -1964,7 +1964,7 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateUser(username: string, body: User, options?: any) {
+        updateUser(username: string, body: User, options?: any) : AxiosPromise<void> {
             return UserApiFp(configuration).updateUser(username, body, options)(axios, basePath);
         },
     };
@@ -1984,7 +1984,7 @@ export interface UserApiInterface {
      * @throws {RequiredError}
      * @memberof UserApiInterface
      */
-    createUser(body: User, options?: any): AxiosPromise<{}>;
+    createUser(body: User, options?: any): AxiosPromise<void>;
 
     /**
      * 
@@ -1994,7 +1994,7 @@ export interface UserApiInterface {
      * @throws {RequiredError}
      * @memberof UserApiInterface
      */
-    createUsersWithArrayInput(body: Array<User>, options?: any): AxiosPromise<{}>;
+    createUsersWithArrayInput(body: Array<User>, options?: any): AxiosPromise<void>;
 
     /**
      * 
@@ -2004,7 +2004,7 @@ export interface UserApiInterface {
      * @throws {RequiredError}
      * @memberof UserApiInterface
      */
-    createUsersWithListInput(body: Array<User>, options?: any): AxiosPromise<{}>;
+    createUsersWithListInput(body: Array<User>, options?: any): AxiosPromise<void>;
 
     /**
      * This can only be done by the logged in user.
@@ -2014,7 +2014,7 @@ export interface UserApiInterface {
      * @throws {RequiredError}
      * @memberof UserApiInterface
      */
-    deleteUser(username: string, options?: any): AxiosPromise<{}>;
+    deleteUser(username: string, options?: any): AxiosPromise<void>;
 
     /**
      * 
@@ -2044,7 +2044,7 @@ export interface UserApiInterface {
      * @throws {RequiredError}
      * @memberof UserApiInterface
      */
-    logoutUser(options?: any): AxiosPromise<{}>;
+    logoutUser(options?: any): AxiosPromise<void>;
 
     /**
      * This can only be done by the logged in user.
@@ -2055,7 +2055,7 @@ export interface UserApiInterface {
      * @throws {RequiredError}
      * @memberof UserApiInterface
      */
-    updateUser(username: string, body: User, options?: any): AxiosPromise<{}>;
+    updateUser(username: string, body: User, options?: any): AxiosPromise<void>;
 
 }
 

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/api.ts
@@ -13,7 +13,7 @@
 
 
 
-export * from './api.another.level/pet-api';
-export * from './api.another.level/store-api';
-export * from './api.another.level/user-api';
+export * from './api/another/level/pet-api';
+export * from './api/another/level/store-api';
+export * from './api/another/level/user-api';
 

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/api/another/level/pet-api.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/api/another/level/pet-api.ts
@@ -565,7 +565,7 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        addPet(body: Pet, options?: any) {
+        addPet(body: Pet, options?: any) : AxiosPromise<void> {
             return PetApiFp(configuration).addPet(body, options)(axios, basePath);
         },
         /**
@@ -576,7 +576,7 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        deletePet(petId: number, apiKey?: string, options?: any) {
+        deletePet(petId: number, apiKey?: string, options?: any) : AxiosPromise<void> {
             return PetApiFp(configuration).deletePet(petId, apiKey, options)(axios, basePath);
         },
         /**
@@ -586,7 +586,7 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: any) {
+        findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: any) : AxiosPromise<Array<Pet>> {
             return PetApiFp(configuration).findPetsByStatus(status, options)(axios, basePath);
         },
         /**
@@ -596,7 +596,7 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        findPetsByTags(tags: Array<string>, options?: any) {
+        findPetsByTags(tags: Array<string>, options?: any) : AxiosPromise<Array<Pet>> {
             return PetApiFp(configuration).findPetsByTags(tags, options)(axios, basePath);
         },
         /**
@@ -606,7 +606,7 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getPetById(petId: number, options?: any) {
+        getPetById(petId: number, options?: any) : AxiosPromise<Pet> {
             return PetApiFp(configuration).getPetById(petId, options)(axios, basePath);
         },
         /**
@@ -616,7 +616,7 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updatePet(body: Pet, options?: any) {
+        updatePet(body: Pet, options?: any) : AxiosPromise<void> {
             return PetApiFp(configuration).updatePet(body, options)(axios, basePath);
         },
         /**
@@ -628,7 +628,7 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updatePetWithForm(petId: number, name?: string, status?: string, options?: any) {
+        updatePetWithForm(petId: number, name?: string, status?: string, options?: any) : AxiosPromise<void> {
             return PetApiFp(configuration).updatePetWithForm(petId, name, status, options)(axios, basePath);
         },
         /**
@@ -640,7 +640,7 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        uploadFile(petId: number, additionalMetadata?: string, file?: any, options?: any) {
+        uploadFile(petId: number, additionalMetadata?: string, file?: any, options?: any) : AxiosPromise<ApiResponse> {
             return PetApiFp(configuration).uploadFile(petId, additionalMetadata, file, options)(axios, basePath);
         },
     };

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/api/another/level/store-api.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/api/another/level/store-api.ts
@@ -251,7 +251,7 @@ export const StoreApiFactory = function (configuration?: Configuration, basePath
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        deleteOrder(orderId: string, options?: any) {
+        deleteOrder(orderId: string, options?: any) : AxiosPromise<void> {
             return StoreApiFp(configuration).deleteOrder(orderId, options)(axios, basePath);
         },
         /**
@@ -260,7 +260,7 @@ export const StoreApiFactory = function (configuration?: Configuration, basePath
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getInventory(options?: any) {
+        getInventory(options?: any) : AxiosPromise<{ [key: string]: number; }> {
             return StoreApiFp(configuration).getInventory(options)(axios, basePath);
         },
         /**
@@ -270,7 +270,7 @@ export const StoreApiFactory = function (configuration?: Configuration, basePath
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getOrderById(orderId: number, options?: any) {
+        getOrderById(orderId: number, options?: any) : AxiosPromise<Order> {
             return StoreApiFp(configuration).getOrderById(orderId, options)(axios, basePath);
         },
         /**
@@ -280,7 +280,7 @@ export const StoreApiFactory = function (configuration?: Configuration, basePath
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        placeOrder(body: Order, options?: any) {
+        placeOrder(body: Order, options?: any) : AxiosPromise<Order> {
             return StoreApiFp(configuration).placeOrder(body, options)(axios, basePath);
         },
     };

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/api/another/level/user-api.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/api/another/level/user-api.ts
@@ -468,7 +468,7 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        createUser(body: User, options?: any) {
+        createUser(body: User, options?: any) : AxiosPromise<void> {
             return UserApiFp(configuration).createUser(body, options)(axios, basePath);
         },
         /**
@@ -478,7 +478,7 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithArrayInput(body: Array<User>, options?: any) {
+        createUsersWithArrayInput(body: Array<User>, options?: any) : AxiosPromise<void> {
             return UserApiFp(configuration).createUsersWithArrayInput(body, options)(axios, basePath);
         },
         /**
@@ -488,7 +488,7 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithListInput(body: Array<User>, options?: any) {
+        createUsersWithListInput(body: Array<User>, options?: any) : AxiosPromise<void> {
             return UserApiFp(configuration).createUsersWithListInput(body, options)(axios, basePath);
         },
         /**
@@ -498,7 +498,7 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        deleteUser(username: string, options?: any) {
+        deleteUser(username: string, options?: any) : AxiosPromise<void> {
             return UserApiFp(configuration).deleteUser(username, options)(axios, basePath);
         },
         /**
@@ -508,7 +508,7 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getUserByName(username: string, options?: any) {
+        getUserByName(username: string, options?: any) : AxiosPromise<User> {
             return UserApiFp(configuration).getUserByName(username, options)(axios, basePath);
         },
         /**
@@ -519,7 +519,7 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        loginUser(username: string, password: string, options?: any) {
+        loginUser(username: string, password: string, options?: any) : AxiosPromise<string> {
             return UserApiFp(configuration).loginUser(username, password, options)(axios, basePath);
         },
         /**
@@ -528,7 +528,7 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        logoutUser(options?: any) {
+        logoutUser(options?: any) : AxiosPromise<void> {
             return UserApiFp(configuration).logoutUser(options)(axios, basePath);
         },
         /**
@@ -539,7 +539,7 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateUser(username: string, body: User, options?: any) {
+        updateUser(username: string, body: User, options?: any) : AxiosPromise<void> {
             return UserApiFp(configuration).updateUser(username, body, options)(axios, basePath);
         },
     };

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version/api.ts
@@ -790,7 +790,7 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        addPet(body: Pet, options?: any) {
+        addPet(body: Pet, options?: any) : AxiosPromise<void> {
             return PetApiFp(configuration).addPet(body, options)(axios, basePath);
         },
         /**
@@ -801,7 +801,7 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        deletePet(petId: number, apiKey?: string, options?: any) {
+        deletePet(petId: number, apiKey?: string, options?: any) : AxiosPromise<void> {
             return PetApiFp(configuration).deletePet(petId, apiKey, options)(axios, basePath);
         },
         /**
@@ -811,7 +811,7 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: any) {
+        findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: any) : AxiosPromise<Array<Pet>> {
             return PetApiFp(configuration).findPetsByStatus(status, options)(axios, basePath);
         },
         /**
@@ -821,7 +821,7 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        findPetsByTags(tags: Array<string>, options?: any) {
+        findPetsByTags(tags: Array<string>, options?: any) : AxiosPromise<Array<Pet>> {
             return PetApiFp(configuration).findPetsByTags(tags, options)(axios, basePath);
         },
         /**
@@ -831,7 +831,7 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getPetById(petId: number, options?: any) {
+        getPetById(petId: number, options?: any) : AxiosPromise<Pet> {
             return PetApiFp(configuration).getPetById(petId, options)(axios, basePath);
         },
         /**
@@ -841,7 +841,7 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updatePet(body: Pet, options?: any) {
+        updatePet(body: Pet, options?: any) : AxiosPromise<void> {
             return PetApiFp(configuration).updatePet(body, options)(axios, basePath);
         },
         /**
@@ -853,7 +853,7 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updatePetWithForm(petId: number, name?: string, status?: string, options?: any) {
+        updatePetWithForm(petId: number, name?: string, status?: string, options?: any) : AxiosPromise<void> {
             return PetApiFp(configuration).updatePetWithForm(petId, name, status, options)(axios, basePath);
         },
         /**
@@ -865,7 +865,7 @@ export const PetApiFactory = function (configuration?: Configuration, basePath?:
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        uploadFile(petId: number, additionalMetadata?: string, file?: any, options?: any) {
+        uploadFile(petId: number, additionalMetadata?: string, file?: any, options?: any) : AxiosPromise<ApiResponse> {
             return PetApiFp(configuration).uploadFile(petId, additionalMetadata, file, options)(axios, basePath);
         },
     };
@@ -1213,7 +1213,7 @@ export const StoreApiFactory = function (configuration?: Configuration, basePath
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        deleteOrder(orderId: string, options?: any) {
+        deleteOrder(orderId: string, options?: any) : AxiosPromise<void> {
             return StoreApiFp(configuration).deleteOrder(orderId, options)(axios, basePath);
         },
         /**
@@ -1222,7 +1222,7 @@ export const StoreApiFactory = function (configuration?: Configuration, basePath
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getInventory(options?: any) {
+        getInventory(options?: any) : AxiosPromise<{ [key: string]: number; }> {
             return StoreApiFp(configuration).getInventory(options)(axios, basePath);
         },
         /**
@@ -1232,7 +1232,7 @@ export const StoreApiFactory = function (configuration?: Configuration, basePath
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getOrderById(orderId: number, options?: any) {
+        getOrderById(orderId: number, options?: any) : AxiosPromise<Order> {
             return StoreApiFp(configuration).getOrderById(orderId, options)(axios, basePath);
         },
         /**
@@ -1242,7 +1242,7 @@ export const StoreApiFactory = function (configuration?: Configuration, basePath
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        placeOrder(body: Order, options?: any) {
+        placeOrder(body: Order, options?: any) : AxiosPromise<Order> {
             return StoreApiFp(configuration).placeOrder(body, options)(axios, basePath);
         },
     };
@@ -1753,7 +1753,7 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        createUser(body: User, options?: any) {
+        createUser(body: User, options?: any) : AxiosPromise<void> {
             return UserApiFp(configuration).createUser(body, options)(axios, basePath);
         },
         /**
@@ -1763,7 +1763,7 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithArrayInput(body: Array<User>, options?: any) {
+        createUsersWithArrayInput(body: Array<User>, options?: any) : AxiosPromise<void> {
             return UserApiFp(configuration).createUsersWithArrayInput(body, options)(axios, basePath);
         },
         /**
@@ -1773,7 +1773,7 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        createUsersWithListInput(body: Array<User>, options?: any) {
+        createUsersWithListInput(body: Array<User>, options?: any) : AxiosPromise<void> {
             return UserApiFp(configuration).createUsersWithListInput(body, options)(axios, basePath);
         },
         /**
@@ -1783,7 +1783,7 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        deleteUser(username: string, options?: any) {
+        deleteUser(username: string, options?: any) : AxiosPromise<void> {
             return UserApiFp(configuration).deleteUser(username, options)(axios, basePath);
         },
         /**
@@ -1793,7 +1793,7 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getUserByName(username: string, options?: any) {
+        getUserByName(username: string, options?: any) : AxiosPromise<User> {
             return UserApiFp(configuration).getUserByName(username, options)(axios, basePath);
         },
         /**
@@ -1804,7 +1804,7 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        loginUser(username: string, password: string, options?: any) {
+        loginUser(username: string, password: string, options?: any) : AxiosPromise<string> {
             return UserApiFp(configuration).loginUser(username, password, options)(axios, basePath);
         },
         /**
@@ -1813,7 +1813,7 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        logoutUser(options?: any) {
+        logoutUser(options?: any) : AxiosPromise<void> {
             return UserApiFp(configuration).logoutUser(options)(axios, basePath);
         },
         /**
@@ -1824,7 +1824,7 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateUser(username: string, body: User, options?: any) {
+        updateUser(username: string, body: User, options?: any) : AxiosPromise<void> {
             return UserApiFp(configuration).updateUser(username, body, options)(axios, basePath);
         },
     };


### PR DESCRIPTION
Templates fixed to have `withInterfaces` and `withSeparateModelsAndApi` options working combine.

Change has been used for generation and successfully compiled (previously it was not possible).

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language. @TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx @macjohnny  @nicokoenig @topce @akehir @petejohansonxo

